### PR TITLE
Add default_call_timeout 

### DIFF
--- a/lib/smppex/mc.ex
+++ b/lib/smppex/mc.ex
@@ -71,7 +71,7 @@ defmodule SMPPEX.MC do
     inspect(Defaults.response_limit())
   } ms.
       - `:default_call_timeout` is an integer greater than zero which specifies how many milliseconds to wait for a reply, or the atom :infinity to wait indefinitely.If no reply is received within the specified time, the function call fails and the caller exits. The default value is #{
-    inspect(Defaults.default_call_timeou())
+    inspect(Defaults.default_call_timeout())
   } ms.
   If `:mc_opts` list of options is ommited, all options take their default values.
   The returned value is either `{:ok, ref}` or `{:error, reason}`. The `ref` can be later used

--- a/lib/smppex/mc.ex
+++ b/lib/smppex/mc.ex
@@ -70,6 +70,9 @@ defmodule SMPPEX.MC do
       - `:response_limit` is the maximum time to wait for a response for a previously sent PDU. If the response is not received within this interval, `handle_resp_timeout` callback is triggered for the original pdu. If the response is received later, it is discarded. The default value is #{
     inspect(Defaults.response_limit())
   } ms.
+      - `:default_call_timeout` is an integer greater than zero which specifies how many milliseconds to wait for a reply, or the atom :infinity to wait indefinitely.If no reply is received within the specified time, the function call fails and the caller exits. The default value is #{
+    inspect(Defaults.default_call_timeou())
+  } ms.
   If `:mc_opts` list of options is ommited, all options take their default values.
   The returned value is either `{:ok, ref}` or `{:error, reason}`. The `ref` can be later used
   to stop the whole MC listener and all sessions received by it.

--- a/lib/smppex/session.ex
+++ b/lib/smppex/session.ex
@@ -46,7 +46,7 @@ defmodule SMPPEX.Session do
     :tick_timer_ref
   ]
 
-  @default_call_timeout 5000
+  @default_call_timeout Keyword.get(session_opts, :default_call_timeout, Defaults.())
 
   @type state :: term
   @type request :: term
@@ -299,8 +299,8 @@ defmodule SMPPEX.Session do
   @doc """
   Sends a PDU from the session to the peer.
   """
-  def send_pdu(pid, pdu) do
-    TransportSession.call(pid, {:send_pdu, pdu})
+  def send_pdu(pid, pdu, timeout \\ @default_call_timeou) do
+    TransportSession.call(pid, {:send_pdu, pdu}, timeout)
   end
 
   @spec stop(session) :: :ok

--- a/lib/smppex/session.ex
+++ b/lib/smppex/session.ex
@@ -46,7 +46,7 @@ defmodule SMPPEX.Session do
     :tick_timer_ref
   ]
 
-  @default_call_timeout Keyword.get(session_opts, :default_call_timeout, Defaults.())
+  @default_call_timeout Defaults.default_call_timeout()
 
   @type state :: term
   @type request :: term
@@ -299,7 +299,7 @@ defmodule SMPPEX.Session do
   @doc """
   Sends a PDU from the session to the peer.
   """
-  def send_pdu(pid, pdu, timeout \\ @default_call_timeou) do
+  def send_pdu(pid, pdu, timeout \\ @default_call_timeout) do
     TransportSession.call(pid, {:send_pdu, pdu}, timeout)
   end
 

--- a/lib/smppex/session/defaults.ex
+++ b/lib/smppex/session/defaults.ex
@@ -7,7 +7,8 @@ defmodule SMPPEX.Session.Defaults do
     session_init_limit: 10_000,
     inactivity_limit: :infinity,
     response_limit: 60_000,
-    timer_resolution: 100
+    timer_resolution: 100,
+    default_call_timeout: 5000
   ]
 
   for {name, value} <- defaults do

--- a/lib/smppex/transport_session.ex
+++ b/lib/smppex/transport_session.ex
@@ -107,7 +107,7 @@ defmodule SMPPEX.TransportSession do
   end
 
   # This `init/1` is never actually called, it's here just to please `GenServer` so that it does not swear
-  
+
   def init(args) do
     {:ok, args}
   end


### PR DESCRIPTION
Add default_call_timeout and upgrade Session.send_pdu/3 where third attribute is timeout.
Such upgrade can be useful for busy sessions